### PR TITLE
Add playback speed 1.5x

### DIFF
--- a/pplay/player/player.cpp
+++ b/pplay/player/player.cpp
@@ -277,7 +277,15 @@ bool Player::onInput(c2d::Input::Player *players) {
     if (keys & c2d::Input::Key::Fire5) {
         setSpeed(1);
     } else if (keys & c2d::Input::Key::Fire6) {
-        double new_speed = mpv->getSpeed() * 2;
+        double old_speed = mpv->getSpeed();
+        double new_speed = old_speed;
+        if (old_speed < 1.5) {
+            new_speed = 1.5;
+        } else if (old_speed < 2) {
+            new_speed = 2;
+        } else {
+            new_speed = old_speed * 2;
+        }
         if (new_speed <= 100) {
             setSpeed(new_speed);
         }


### PR DESCRIPTION
Hi,

Thanks for your hard work on pplay, the app works nicely 👍

I often watch shows at 1.5x speed and missed the feature on pplay, so here is a small contribution to add it. Basically, all it does is adding 1.5x between 1.0x and 2.0x playback speeds. I have not been able to recompile the project due to all the dependencies it requires but I'm fairly confident the change is valid C++ and should work just well. Looking forward to seeing it included in the next release :)